### PR TITLE
Generic link

### DIFF
--- a/mandrill-webhooks.js
+++ b/mandrill-webhooks.js
@@ -90,7 +90,9 @@ var giveUpHooks = exports.giveUpHooks = function (){
       return
     webhooks.forEach(function (){
       nightmare
-        .goto("https://mandrillapp.com/settings/webhooks/batches?id=3")
+        .goto("https://mandrillapp.com/settings/webhooks/")
+        .click('p.stat > a')
+        .wait()
         .click('td > a.btn.btn-small.btn-danger')
         .wait()
     })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a nightmare script to clean out backlogged mandrill webhooks.",
   "main": "mandrill-webhooks.js",
   "dependencies": {
-    "nightmare": "^1.1.0"
+    "nightmare": "1.6.5"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Updated nightmare and added more generic way of finding webhook links to close. This fixes the bug where it wouldn't find the right link depending on the mandrill account.
